### PR TITLE
Fix linter issues

### DIFF
--- a/mcp-host/pkg/mcphost/host.go
+++ b/mcp-host/pkg/mcphost/host.go
@@ -56,7 +56,7 @@ func (l *MCPHost) RunUserQuery(ctx context.Context, query string) (string, error
 	if err := json.Unmarshal([]byte(planJSON), &plan); err != nil {
 		// This is a fallback if the LLM does not return a valid JSON for tool calling
 		// or if the response is a direct answer instead of a tool call plan.
-		return "", fmt.Errorf("Failed to parse LLM plan from JSON: %v", err) // Exit if we can't parse a tool call
+		return "", fmt.Errorf("failed to parse LLM plan from JSON: %v", err) // Exit if we can't parse a tool call
 	}
 
 	// Check if a tool name was actually provided by the LLM
@@ -78,17 +78,17 @@ func (l *MCPHost) RunUserQuery(ctx context.Context, query string) (string, error
 		log.Printf("Tool '%s' not found in Go server, trying Python server: %v", plan.ToolName, err)
 		response, err = l.mcpClientPython.CallTool(ctx, request)
 		if err != nil {
-			return "", fmt.Errorf("Tool call failed on both servers: %v", err)
+			return "", fmt.Errorf("tool call failed on both servers: %v", err)
 		}
 	}
 
 	if response.IsError {
-		return "", fmt.Errorf("Tool call error: %s", response.Content)
+		return "", fmt.Errorf("tool call error: %s", response.Content)
 	}
 
 	textResponse, ok := mcp.AsTextContent(response.Content[0])
 	if !ok {
-		return "", fmt.Errorf("Tool call did not return text content: %v", response.Content)
+		return "", fmt.Errorf("tool call did not return text content: %v", response.Content)
 	}
 
 	return textResponse.Text, nil

--- a/mcp-host/pkg/mcphost/llm-client.go
+++ b/mcp-host/pkg/mcphost/llm-client.go
@@ -89,7 +89,9 @@ func (c LLMClient) CallLLM(userInput string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/mcp-server-go/internal/mcpserver/http.go
+++ b/mcp-server-go/internal/mcpserver/http.go
@@ -24,6 +24,8 @@ func openaiSpecHndler() http.HandlerFunc {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		w.Write(openAPISpec)
+		if _, err := w.Write(openAPISpec); err != nil {
+			http.Error(w, "Failed to write OpenAPI spec", http.StatusInternalServerError)
+		}
 	}
 }

--- a/mcp-server-go/internal/mcpserver/mcp-server.go
+++ b/mcp-server-go/internal/mcpserver/mcp-server.go
@@ -66,7 +66,11 @@ func NewMCPServer() (MCPServer, error) {
 // It listens for incoming requests and handles tool calls as defined in the MCP server.
 func (s MCPServer) Start(address string) error {
 	// start the MCP server spec handler
-	go startOpenAPIServer()
+	go func() {
+		if err := startOpenAPIServer(); err != nil {
+			log.Fatalf("Failed to start OpenAPI spec server: %v", err)
+		}
+	}()
 
 	// Start StreamableHTTP server
 	log.Println("Starting StreamableHTTP server on :8090")


### PR DESCRIPTION
This pull request focuses on improving error handling and code robustness across several components of the MCP system. Key changes include better error reporting for failed operations, ensuring proper resource cleanup, and improving logging for critical failures.

### Error handling improvements:

* [`mcp-host/pkg/mcphost/host.go`](diffhunk://#diff-39b938f0d76a2fc4978f2c217fa05c71cebd0ed99114bfdec851b8bea42b1f15L59-R59): Updated error messages in `RunUserQuery` to use consistent lowercase formatting for better readability and adherence to Go conventions. [[1]](diffhunk://#diff-39b938f0d76a2fc4978f2c217fa05c71cebd0ed99114bfdec851b8bea42b1f15L59-R59) [[2]](diffhunk://#diff-39b938f0d76a2fc4978f2c217fa05c71cebd0ed99114bfdec851b8bea42b1f15L81-R91)
* [`mcp-server-go/internal/mcpserver/http.go`](diffhunk://#diff-7670ac183f92d4a2e336a48b50f987fa8e9f485692e604192f3ec6d6f2220c4aL27-R29): Enhanced error handling in `openaiSpecHndler` by checking the result of `w.Write` and responding with an HTTP error if the write operation fails.

### Resource cleanup:

* [`mcp-host/pkg/mcphost/llm-client.go`](diffhunk://#diff-91cbbc1a83874b8cf43a17fff67b376e97c9e632fed34a67b2ccfecf48c00467L92-R94): Replaced `defer resp.Body.Close()` with a closure to safely handle errors during the `Close` operation.

### Logging improvements:

* [`mcp-server-go/internal/mcpserver/mcp-server.go`](diffhunk://#diff-b9d2188769ec6b6b95173dbc51399ee83e0a2c5f4b5b1bcd0ccb03456b3e667eL69-R73): Wrapped `startOpenAPIServer` in a goroutine with error handling to log fatal errors if the server fails to start.